### PR TITLE
Support input, blur and focus events on md-input

### DIFF
--- a/src/components/forms/md-input.vue
+++ b/src/components/forms/md-input.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="input-field">
         <md-icon v-if="iconText" :class="{'active':focus}" :text="iconText" :pos="iconPos"></md-icon>
-        <input v-model="mdValue" :id="id" v-el:input :name="name" :value="value" :placeholder="placeholder" :type="type" :disabled="disabled" :required="required" @focus="focus=true" @blur="focus=false" lazy>
+        <input v-model="mdValue" :id="id" v-el:input :name="name" :value="value" :placeholder="placeholder" :type="type" :disabled="disabled" :required="required" @input="$emit('input', $event)" @focus="focus=true; $emit('focus', $event)" @blur="focus=false; $emit('blur', $event)" lazy>
         <label :for="id" :class="{'active':labelActive}"><slot></slot></label>
 </div>
 </template>


### PR DESCRIPTION
Adds pass-through `$emit` calls to allow direct event binding to the component.

As a proposal to solve https://github.com/monterail/vuelidate/issues/27

You probably want to add similar handlers to other components too if this will be accepted.